### PR TITLE
Corrected typo in link_all_units.Rd documentation

### DIFF
--- a/R/create_impact_table_single.R
+++ b/R/create_impact_table_single.R
@@ -36,7 +36,7 @@ create_impact_table_single <- function(data.linked,
 
   year.use <- as( substr( map.month, 1, 4), 'integer')
   datareduced <-
-    data.linked[month == map.month & ID == map.unitID]
+    data.linked[month == map.month & unitID == map.unitID]
   dataunits <- data.units[ID == map.unitID & year == year.use]
 
   if( link.to == 'zips'){

--- a/R/link_all_units.R
+++ b/R/link_all_units.R
@@ -145,7 +145,9 @@ link_all_units<- function(units.run,
   if( link.to == 'grids')
     out <- units.run[, grids_link_parallel(.SD), by = seq_len(nrow(units.run))]
 
-  out[, comb := paste("month: ", out[, .(month)], " unitID :", out[, .(unit)], sep = "")]
+  print(out)
+    
+  out[, comb := paste("month: ", out[, .(month)], " unitID : ", out[, .(unit)], sep = "")]
   out[, seq_len := NULL]
   return(out)
 }

--- a/R/link_all_units.R
+++ b/R/link_all_units.R
@@ -132,7 +132,7 @@ link_all_units<- function(units.run,
     linked_grids <- data.table::rbindlist(Filter(is.data.table, linked_grids))
     message(paste("processed unit", unit$ID, ""))
 
-    linked_grids[, month := as( month, 'character')]
+    linked_grids[, month := as( year.mons, 'character')]
     return(linked_grids)
   }
 

--- a/R/link_all_units.R
+++ b/R/link_all_units.R
@@ -88,7 +88,7 @@ link_all_units<- function(units.run,
     linked_zips <- data.table::rbindlist(Filter(is.data.table, linked_zips))
     message(paste("processed unit", unit$ID, ""))
 
-    linked_zips[, month := as( month, 'character')]
+    linked_zips[, month := as( year.mons, 'character')]
     return(linked_zips)
   }
 
@@ -110,7 +110,7 @@ link_all_units<- function(units.run,
     linked_counties <- data.table::rbindlist(Filter(is.data.table, linked_counties))
     message(paste("processed unit", unit$ID, ""))
 
-    linked_counties[, month := as( month, 'character')]
+    linked_counties[, month := as( year.mons, 'character')]
     return(linked_counties)
   }
 
@@ -145,7 +145,7 @@ link_all_units<- function(units.run,
   if( link.to == 'grids')
     out <- units.run[, grids_link_parallel(.SD), by = seq_len(nrow(units.run))]
 
-  out[, comb := paste("month: ", out[, .(month)], " unitID :", out[, .(ID)], sep = "")]
+  out[, comb := paste("month: ", out[, .(month)], " unitID :", out[, .(unit)], sep = "")]
   out[, seq_len := NULL]
   return(out)
 }

--- a/R/link_all_units.R
+++ b/R/link_all_units.R
@@ -145,7 +145,7 @@ link_all_units<- function(units.run,
   if( link.to == 'grids')
     out <- units.run[, grids_link_parallel(.SD), by = seq_len(nrow(units.run))]
 
-  out[, comb := paste("month: ", out[, month], " unitID :", out[, ID], sep = "")]
+  out[, comb := paste("month: ", out[, .(month)], " unitID :", out[, .(ID)], sep = "")]
   out[, seq_len := NULL]
   return(out)
 }

--- a/man/link_all_units.Rd
+++ b/man/link_all_units.Rd
@@ -30,7 +30,7 @@ link_all_units(units.run, link.to = "zips", mc.cores = detectCores(),
 
 \item{overwrite}{`overwrite = FALSE` by default. Would you like to overwrite files that already exist?}
 
-\item{start.end}{this argument is not necessary, but can be used if the user is interested in specifying a specific date to end the analysis with as opposed to using months. For example `start.date="2005-01-02"` for 2 January 2005.This argument are set to `NULL` by default and the function computes the start and the end dates using the `year.mons` provided.}
+\item{end.date}{this argument is not necessary, but can be used if the user is interested in specifying a specific date to end the analysis with as opposed to using months. For example `start.date="2005-01-02"` for 2 January 2005. This argument are set to `NULL` by default and the function computes the start and the end dates using the `year.mons` provided.}
 }
 \value{
 vector of months that you can loop over


### PR DESCRIPTION
In the documentation for link_all_units the end.date option was named start.end, probably a typo. 