### PR TITLE
Spatial transform problem for the us_counties

### DIFF
--- a/R/link_all_units_subfun.R
+++ b/R/link_all_units_subfun.R
@@ -461,9 +461,10 @@ disperser_link_counties <- function( month_YYYYMM = NULL,
     } else
       d_trim <- d
 
-    counties.sp <- sf::as_Spatial( counties)
-    p4s <- "+proj=aea +lat_1=20 +lat_2=60 +lat_0=40 +lon_0=-96 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m"
-    counties.sp <- spTransform(counties.sp, p4s)
+      counties.sp <- sf::as_Spatial( counties)
+      p4s <- "+init=epsg:3857"
+      ## p4s <- "+proj=aea +lat_1=20 +lat_2=60 +lat_0=40 +lon_0=-96 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m"
+      counties.sp <- spTransform(counties.sp, p4s)
 
     disp_df_link <- link_to( d = d_trim,
                              link.to = 'counties',

--- a/man/link_all_units.Rd
+++ b/man/link_all_units.Rd
@@ -30,7 +30,7 @@ link_all_units(units.run, link.to = "zips", mc.cores = detectCores(),
 
 \item{overwrite}{`overwrite = FALSE` by default. Would you like to overwrite files that already exist?}
 
-\item{start.end}{this argument is not necessary, but can be used if the user is interested in specifying a specific date to end the analysis with as opposed to using months. For example `start.date="2005-01-02"` for 2 January 2005.This argument are set to `NULL` by default and the function computes the start and the end dates using the `year.mons` provided.}
+\item{end.date}{this argument is not necessary, but can be used if the user is interested in specifying a specific date to end the analysis with as opposed to using months. For example `start.date="2005-01-02"` for 2 January 2005.This argument are set to `NULL` by default and the function computes the start and the end dates using the `year.mons` provided.}
 }
 \value{
 vector of months that you can loop over


### PR DESCRIPTION
The string p4s 
`p4s <- "+proj=aea +lat_1=20 +lat_2=60 +lat_0=40 +lon_0=-96 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m"`
did not work in the spTransform() function for the **counties** data with the error `non finite transformation detected:`.  Substituting `p4s <- "+init=epsg:3857"` appears to work (but I am not sure that it is correct.)

There was also a minor typo in the documentation for link_all_units  (`start.end` should be `end.date`)

